### PR TITLE
Documentation notes and randomize test set

### DIFF
--- a/stickleback/data.py
+++ b/stickleback/data.py
@@ -4,10 +4,19 @@ from typing import Dict, Tuple
 
 def load_lunges() -> Tuple[Dict[str, pd.DataFrame], 
                            Dict[str, pd.DatetimeIndex]]:
-    """Load sample data.
+    """Load sample sensor and event data.
 
     Loads a small dataset containing six blue whale deployments and labeled 
-    lunge-feeding behaviors.
+    lunge-feeding behaviors. 
+
+    Transforms data to required Stickleback data format:
+        sensors (Dict[str, pd.DataFrame]): A dictionary keyed by the
+            deployment ID string, with a Pandas' dataframe value consisting
+            of a Pandas' datetime index and remaining sensor measurement
+            columns at each index time.
+        events (Dict[str, pd.DatetimeIndex]): A dictionary keyed by the
+            deployment ID string, with a Pandas' datetime index for each
+            timestamp in `sensors` where the event type of interest occurred.
 
     Returns:
         Tuple[Dict[str, pd.DataFrame], Dict[str, pd.DatetimeIndex]]: Sensors 

--- a/stickleback/stickleback.py
+++ b/stickleback/stickleback.py
@@ -74,7 +74,7 @@ class Stickleback:
         """Fits a Stickleback model.
 
         Args:
-            sensors (Dict[str, pd.DataFrame]): Sensor data.
+            sensors (Dict[str, pd.DataFrame]): Sensor data as a dictionary of
             events (Dict[str, pd.DatetimeIndex]): Labeled events.
             mask (Dict[str, np.ndarray], optional): Training mask. Only trains 
                 model on windows in sensors[deployid] where mask[deployid] is 
@@ -154,7 +154,9 @@ class Stickleback:
         return {d: (local_proba[d], global_pred[d]) for d in global_pred}
 
     def assess(self, predicted: prediction_T, events: events_T) -> outcomes_T:
-        """Assess prediction accuracy
+        """Assess prediction accuracy to determine if each data point is a
+                true positive, false negative, etc. according to the prediction
+                `predicted`.
 
         Args:
             predicted (Dict[str, Tuple[pd.Series, pd.DatetimeIndex]]): Model 
@@ -284,8 +286,8 @@ class Stickleback:
         Args:
             events_nested (Dict[str, pd.DataFrame]): A dictionary of sensor 
                 data windows containing labeled events, keyed by deployment ID.
-            nonevents_nested (Dict[str, pd.DataFrame]): As events_nested, but 
-                windows contain non-events.
+            nonevents_nested (Dict[str, pd.DataFrame]): Same as events_nested, 
+                but windows contain non-events.
             sensors (Dict[str, pd.DataFrame]): Sensor data.
             events (Dict[str, pd.DatetimeIndex]): Labeled events.
             mask (Dict[str, np.ndarray]): Training mask.
@@ -357,6 +359,21 @@ class Stickleback:
                nonevents: nested_T, 
                sensors: sensors_T, 
                outcomes: outcomes_T) -> nested_T:
+        """Select false positive samples from initial training round to add to 
+                nonevent samples for boosted training round.
+
+        Args:
+            nonevents (Dict[str, pd.Series]): A dictionary of sensor 
+                data windows containing non-events, keyed by deployment ID.
+            sensors (Dict[str, pd.DataFrame]): Complete sensor training data.
+            outcomes (Dict[str, pd.Series]): A dictionary of prediction outcome 
+                Series with values in ("TP", "FP", and "FN") keyed by deployment
+                ID.
+
+        Returns:
+            Dict[str, pd.Series]: Dictionary of sensor data windows containing 
+            non-events with a boosted number of FP events, keyed by deployment ID.
+        """
         fps = {d: o.index[o == "FP"] for d, o in outcomes.items()}
         nested_fps = sb_util.extract_nested(sensors, fps, self.win_size)
         boosted_nonevents = dict()

--- a/stickleback/stickleback.py
+++ b/stickleback/stickleback.py
@@ -74,11 +74,14 @@ class Stickleback:
         """Fits a Stickleback model.
 
         Args:
-            sensors (Dict[str, pd.DataFrame]): Sensor data as a dictionary of
+            sensors (Dict[str, pd.DataFrame]): Sensor data.
             events (Dict[str, pd.DatetimeIndex]): Labeled events.
             mask (Dict[str, np.ndarray], optional): Training mask. Only trains 
                 model on windows in sensors[deployid] where mask[deployid] is 
                 True. If None, no mask applied. Defaults to None.
+
+            See data.py for a detailed description of the required Stickleback
+            format for the `sensors` and `events` data objects.
         """
         # Local step
         if self.max_events is None:

--- a/stickleback/types.py
+++ b/stickleback/types.py
@@ -2,6 +2,8 @@ import numpy as np
 import pandas as pd
 from typing import Dict, Tuple
 
+# Instantiate elements
+
 events_T = Dict[str, pd.DatetimeIndex]
 mask_T = Dict[str, np.ndarray]
 nested_T = Dict[str, pd.DataFrame]

--- a/tests/testseed.py
+++ b/tests/testseed.py
@@ -6,13 +6,17 @@ from stickleback.stickleback import Stickleback
 import stickleback.data
 import stickleback.util
 import unittest
+from numpy.random import default_rng
 
 # Load sample data
 sensors, events = stickleback.data.load_lunges()
 
 # Split into test and train (2 deployments each)
-train_deployids = list(sensors.keys())[0:2]
-test_deployids = list(sensors.keys())[2:4]
+rng = default_rng(12345)
+key_list = list(sensors.keys())
+rng.shuffle(list(key_list))  # randomize key order inplace
+test_deployids = key_list[0:2]
+train_deployids = key_list[2:]
 sensors_train = {k: sensors[k] for k in train_deployids}
 sensors_test = {k: sensors[k] for k in test_deployids}
 events_train = {k: events[k] for k in train_deployids}


### PR DESCRIPTION
@FlukeAndFeather, mainly small additions / clarifications.  Two main points:
1.  Added written explanation for Stickleback format for sensors and events (since users with new data need to get data into this format).
2.  Added randomization to the train and test data set split (made reproducible with a seed).  My experience is that this is a must have otherwise it is a red flag.  It would be good to likewise update the README (I think the exact same code can be copy pasted), but I didn't want to risk messing up the plot rendering by attempting it myself. 